### PR TITLE
bumps versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "underscore": "1.8.3",
-    "typescript": "2.5.2"
+    "typescript": "2.8.4"
   },
   "typings": "./dist/index.d.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
   "name": "ts-structure-parser",
-  "version": "0.0.16",
+  "version": "0.1.0",
   "private": false,
   "main": "dist/index.js",
   "scripts": {
     "build": "rimraf dist && tsc",
-    "pullall" : "dev-env-installer pullall",
-    "buildall" : "dev-env-installer buildall",
-    "testall" : "dev-env-installer testall",
+    "pullall": "dev-env-installer pullall",
+    "buildall": "dev-env-installer buildall",
+    "testall": "dev-env-installer testall",
     "devInstall": "dev-env-installer install"
   },
   "dependencies": {
-    "underscore": "1.8.3",
-    "typescript": "2.5.2"
+    "underscore": "1.9.1",
+    "typescript": "3.0.1"
   },
   "typings": "./dist/index.d.ts",
   "repository": {
@@ -33,6 +33,6 @@
     "@types/node": "4.2.20",
     "@types/underscore": "1.8.3",
     "dev-env-installer": "0.0.14",
-    "rimraf":"*"
+    "rimraf": "*"
   }
 }


### PR DESCRIPTION
Fixes NexusIQ scan about typescript dependency:

![image](https://user-images.githubusercontent.com/23746912/44533883-d57bce00-a6cc-11e8-8984-442b0d3e22eb.png)

Bumping versions the report is clean:

![image](https://user-images.githubusercontent.com/23746912/44533969-107e0180-a6cd-11e8-91a4-9e0e23d92bc4.png)
